### PR TITLE
feat : 화상 멘토링 signaling 기능 백엔드 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/backend/src/main/java/org/example/backend/config/WebConfig.java
+++ b/backend/src/main/java/org/example/backend/config/WebConfig.java
@@ -8,6 +8,7 @@ import org.springframework.web.filter.CorsFilter;
 
 import java.util.Arrays;
 
+// CORS 설정 config
 @Configuration
 public class WebConfig {
 

--- a/backend/src/main/java/org/example/backend/config/WebSocketConfig.java
+++ b/backend/src/main/java/org/example/backend/config/WebSocketConfig.java
@@ -1,0 +1,28 @@
+package org.example.backend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.WebSocketMessage;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry){
+        registry.addEndpoint("/ws") // 클라이언트 연결 주소
+                .setAllowedOriginPatterns("*")
+                .withSockJS(); // 선택 (브라우저 호환성)
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic"); // 서버 → 클라이언트
+        registry.setApplicationDestinationPrefixes("/app"); // 클라이언트 → 서버
+    }
+
+}

--- a/backend/src/main/java/org/example/backend/config/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/org/example/backend/config/jwt/JwtTokenProvider.java
@@ -58,6 +58,7 @@ public class JwtTokenProvider {
         );
     }
 
+
     // 토큰 유효성 검사
     public boolean validateToken(String token){
         try{

--- a/backend/src/main/java/org/example/backend/signaling/controller/SignalingController.java
+++ b/backend/src/main/java/org/example/backend/signaling/controller/SignalingController.java
@@ -1,0 +1,40 @@
+package org.example.backend.signaling.controller;
+
+import org.example.backend.signaling.dto.SignalMessageDTO;
+import org.springframework.messaging.handler.annotation.*;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+import java.security.Principal;
+import java.util.Map;
+
+@Controller
+public class SignalingController {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public SignalingController(SimpMessagingTemplate messagingTemplate) {
+        this.messagingTemplate = messagingTemplate;
+    }
+
+    @MessageMapping("/signal") // 클라이언트 → /app/signal
+    public void handleSignal(
+            @Payload SignalMessageDTO message,
+            @Header("simpSessionAttributes") Map<String, Object> attributes
+    ) {
+        // 1. WebSocket 세션에서 userId 꺼내기
+        Long userId = (Long) attributes.get("userId"); //
+        if (userId == null) {
+            System.out.println("Unauthorized WebSocket message blocked.");
+            return;
+        }
+
+        // 2. 메시지에 sender 강제 주입 (위조 방지)
+        message.setSender(String.valueOf(userId));
+
+        // 3. 구독자들에게 전달
+        messagingTemplate.convertAndSend(
+                "/topic/room/" + message.getRoomId(),
+                message
+        );
+    }
+}

--- a/backend/src/main/java/org/example/backend/signaling/dto/SignalMessageDTO.java
+++ b/backend/src/main/java/org/example/backend/signaling/dto/SignalMessageDTO.java
@@ -1,0 +1,20 @@
+package org.example.backend.signaling.dto;
+
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SignalMessageDTO {
+    private String type;      // 메시지 종류 (join, offer, answer, candidate, startMentoring)
+    private String roomId;    // 방 ID
+    private String sender;    // 보낸 사람
+    private String receiver;  // 받을 사람 (1:1 연결 시)
+    private String chat;      // 추후 텍스트 채팅을 위해 추가
+    private Object data;      // 실제 내용 (SDP, ICE, 시작시간 등)
+
+
+}


### PR DESCRIPTION
1. WebSocket signaling 서버 구성
- /ws 엔드포인트로 SockJS + STOMP 기반 WebSocket 연결 허용
- /app/signal 경로로 클라이언트 메시지 수신
- /topic/room/{roomId} 경로로 동일 방 유저에게 signaling 메시지 브로드캐스트

2. WebSocket 인증 처리
- WebSocketHandshakeInterceptor 구현
- HTTP 헤더의 JWT 토큰을 파싱하여 유효성 검사 후 userId를 WebSocket 세션에 저장
- 인증 실패 시 WebSocket 연결 거부

3. signaling 메시지 DTO 정의
- SignalMessageDTO 생성
- offer, answer, candidate, join, startMentoring 등 다양한 메시지 타입 처리
- sender, receiver, roomId, data 필드 포함

4. signaling 컨트롤러 구현
- @MessageMapping("/signal") 엔드포인트 생성
- WebSocket 세션에서 userId 추출하여 sender로 설정
- 수신자에게 메시지 중계 (broadcast 방식)

5. CORS 및 WebSocket 설정 보완
- WebConfig.java에 프론트 도메인 허용 추가
- WebSocketConfig.java에 엔드포인트 및 메시지 라우팅 설정