### PR TITLE
feat : feat: WebSocket + STOMP + JWT 인증 연동 구현

### DIFF
--- a/backend/src/main/java/org/example/backend/config/StompHandler.java
+++ b/backend/src/main/java/org/example/backend/config/StompHandler.java
@@ -1,0 +1,53 @@
+package org.example.backend.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.*;
+import org.springframework.messaging.simp.stomp.*;
+import org.springframework.messaging.support.*;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Component;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StompHandler implements ChannelInterceptor {
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+            Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+            Object userIdObj = sessionAttributes.get("userId");
+
+            Long userId = null;
+            if (userIdObj instanceof Long) {
+                userId = (Long) userIdObj;
+            } else if (userIdObj instanceof String) {
+                try {
+                    userId = Long.parseLong((String) userIdObj);
+                } catch (NumberFormatException e) {
+                    log.warn("STOMP 인증 실패: userId 형변환 오류");
+                }
+            }
+
+            if (userId != null) {
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(userId, null, List.of());
+                accessor.setUser(authentication);
+                log.info("STOMP 연결 인증 완료: userId={}", userId);
+            } else {
+                log.warn("STOMP 인증 실패: userId 없음");
+                log.info("Session Attributes = {}", sessionAttributes);
+                throw new IllegalArgumentException("유저 인증 실패");
+            }
+        }
+
+        return message;
+    }
+}

--- a/backend/src/main/java/org/example/backend/config/WebSocketConfig.java
+++ b/backend/src/main/java/org/example/backend/config/WebSocketConfig.java
@@ -1,28 +1,62 @@
 package org.example.backend.config;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.WebSocketMessage;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
+import java.security.Principal;
 
+import java.util.Map;
 
+@RequiredArgsConstructor
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
+    private final WebSocketHandshakeInterceptor handshakeInterceptor;
+    private final StompHandler stompHandler;
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompHandler);
+    }
+
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry){
         registry.addEndpoint("/ws") // 클라이언트 연결 주소
-                .setAllowedOriginPatterns("*")
-                .withSockJS(); // 선택 (브라우저 호환성)
+                .setHandshakeHandler(handshakeHandler())
+                .addInterceptors(handshakeInterceptor) // 인터셉터 반드시 등록
+                .setAllowedOriginPatterns("*");
     }
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.enableSimpleBroker("/topic"); // 서버 → 클라이언트
         registry.setApplicationDestinationPrefixes("/app"); // 클라이언트 → 서버
+    }
+
+    @Bean
+    public DefaultHandshakeHandler handshakeHandler() {
+        return new DefaultHandshakeHandler() {
+            @Override
+            protected Principal determineUser(ServerHttpRequest request,
+                                              WebSocketHandler wsHandler,
+                                              Map<String, Object> attributes) {
+                Object userId = attributes.get("userId");
+                if (userId != null) {
+                    return () -> String.valueOf(userId);
+                }
+                return null;
+            }
+        };
     }
 
 }

--- a/backend/src/main/java/org/example/backend/config/WebSocketHandshakeInterceptor.java
+++ b/backend/src/main/java/org/example/backend/config/WebSocketHandshakeInterceptor.java
@@ -1,7 +1,9 @@
 package org.example.backend.config;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import org.example.backend.config.jwt.JwtTokenProvider;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.http.server.ServletServerHttpRequest;
@@ -37,7 +39,7 @@ public class WebSocketHandshakeInterceptor implements HandshakeInterceptor {
                 return true;
             }
         }
-
+        response.setStatusCode(HttpStatus.UNAUTHORIZED);
         return false; // 인증 실패 → WebSocket 연결 거부
     }
 
@@ -48,11 +50,14 @@ public class WebSocketHandshakeInterceptor implements HandshakeInterceptor {
     }
 
     private String resolveToken(HttpServletRequest request) {
-        // 예: Authorization: Bearer eyJ...
-        String bearer = request.getHeader("Authorization");
-        if (bearer != null && bearer.startsWith("Bearer ")) {
-            return bearer.substring(7);
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if ("AccessToken".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
         }
         return null;
     }
+
 }

--- a/backend/src/main/java/org/example/backend/room/domain/MentoringRecord.java
+++ b/backend/src/main/java/org/example/backend/room/domain/MentoringRecord.java
@@ -9,7 +9,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class InterviewRecord {
+public class MentoringRecord {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -17,7 +17,7 @@ public class InterviewRecord {
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "room_id", nullable = false)
-    private InterviewRoom room;
+    private MentoringRoom room;
 
     @Lob
     private String sttText;

--- a/backend/src/main/java/org/example/backend/room/domain/MentoringRoom.java
+++ b/backend/src/main/java/org/example/backend/room/domain/MentoringRoom.java
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class InterviewRoom extends BaseTimeEntity {
+public class MentoringRoom extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
- WebSocketHandshakeInterceptor 구현
  - HttpOnly 쿠키에서 AccessToken 추출
  - JwtTokenProvider로 토큰 유효성 검증
  - userId를 WebSocket 세션 attributes에 저장

- DefaultHandshakeHandler 구현
  - WebSocket 연결 시 Principal을 userId로 설정

- StompHandler 구현
  - STOMP CONNECT 요청 시 sessionAttributes에서 userId 추출
  - 인증된 사용자만 메시지 전송 가능하도록 처리

- WebSocketConfig 설정
  - /ws 엔드포인트에 handshakeInterceptor 및 stompHandler 등록
  - STOMP 메시지 prefix, broker 설정 완료

※ 현재는 WebSocket 연결 및 인증까지만 완료된 상태이며, 방 생성 및 입장, 중복 접속 제한 등은 이후 구현 예정
