### PR TITLE
feat : 예약 승인 및 MentorignRoom 생성 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/backend/src/main/java/org/example/backend/reservation/controller/ReservationController.java
+++ b/backend/src/main/java/org/example/backend/reservation/controller/ReservationController.java
@@ -1,6 +1,7 @@
 package org.example.backend.reservation.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.example.backend.reservation.dto.ApproveReservationResponseDTO;
 import org.example.backend.reservation.dto.ReservationRequestDto;
 import org.example.backend.reservation.dto.ReservationResponseDto;
 import org.example.backend.reservation.service.ReservationService;
@@ -23,6 +24,12 @@ public class ReservationController {
   ) {
     Long userId = userDetails.getUserId(); // JWT에서 추출된 사용자 ID
     ReservationResponseDto response = reservationService.createReservation(requestDto, userId);
-    return ResponseEntity.ok(response);//✅ 예약 완료 응답 반환
+    return ResponseEntity.ok(response);//예약 완료 응답 반환
+  }
+
+  @PatchMapping("/{reservationId}/approve")
+  public ResponseEntity<ApproveReservationResponseDTO> approve(@PathVariable Long reservationId) {
+    ApproveReservationResponseDTO response = reservationService.approveReservationResponse(reservationId);
+    return ResponseEntity.ok(response);
   }
 }

--- a/backend/src/main/java/org/example/backend/reservation/domain/MentoringReservation.java
+++ b/backend/src/main/java/org/example/backend/reservation/domain/MentoringReservation.java
@@ -40,6 +40,14 @@ public class MentoringReservation extends BaseTimeEntity {
     @NotNull
     @Enumerated(EnumType.STRING)
     private ReservationStatus status;
+
+    public void approve() {
+        this.status = ReservationStatus.ACCEPT;
+    }
+
+    public void reject() {
+        this.status = ReservationStatus.REJECT;
+    }
 }
 
 //    | 개념                        | 설명                                |

--- a/backend/src/main/java/org/example/backend/reservation/domain/ReservationActionType.java
+++ b/backend/src/main/java/org/example/backend/reservation/domain/ReservationActionType.java
@@ -1,6 +1,0 @@
-package org.example.backend.reservation.domain;
-
-public enum ReservationActionType {
-    ACCEPT,
-    REJECT
-}

--- a/backend/src/main/java/org/example/backend/reservation/domain/ReservationStatus.java
+++ b/backend/src/main/java/org/example/backend/reservation/domain/ReservationStatus.java
@@ -2,5 +2,5 @@
 package org.example.backend.reservation.domain;
 
 public enum ReservationStatus {
-    WAITING, COMPLETED, CANCELLED
+    ACCEPT,WAITING,REJECT
 }

--- a/backend/src/main/java/org/example/backend/reservation/dto/ApproveReservationResponseDTO.java
+++ b/backend/src/main/java/org/example/backend/reservation/dto/ApproveReservationResponseDTO.java
@@ -1,0 +1,24 @@
+package org.example.backend.reservation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.example.backend.room.domain.MentoringRoom;
+
+@Getter
+@AllArgsConstructor
+public class ApproveReservationResponseDTO {
+    private Long roomId;
+    private String roomCode;
+    private String mentorNickname;
+    private String menteeNickname;
+
+    public static ApproveReservationResponseDTO of(MentoringRoom room) {
+        return new ApproveReservationResponseDTO(
+                room.getRoomId(),
+                room.getRoomCode(),
+                room.getMentor().getUser().getNickname(),
+                room.getUser().getNickname()
+        );
+    }
+}
+

--- a/backend/src/main/java/org/example/backend/reservation/repository/ReservationRepository.java
+++ b/backend/src/main/java/org/example/backend/reservation/repository/ReservationRepository.java
@@ -8,6 +8,6 @@ import java.time.LocalDateTime;
 
 public interface ReservationRepository extends JpaRepository<MentoringReservation, Long> {
 
-  // ✅ 예약 시간 중복 체크용 메서드
+  // 예약 시간 중복 체크용 메서드
   boolean existsByMentorAndReservationTime(MentorUser mentor, LocalDateTime reservationTime);
 }

--- a/backend/src/main/java/org/example/backend/reservation/service/ReservationService.java
+++ b/backend/src/main/java/org/example/backend/reservation/service/ReservationService.java
@@ -1,8 +1,10 @@
 package org.example.backend.reservation.service;
 
+import org.example.backend.reservation.dto.ApproveReservationResponseDTO;
 import org.example.backend.reservation.dto.ReservationRequestDto;
 import org.example.backend.reservation.dto.ReservationResponseDto;
 
 public interface ReservationService {
   ReservationResponseDto createReservation(ReservationRequestDto requestDto, Long userId);
+  ApproveReservationResponseDTO approveReservationResponse(Long reservationId);
 }

--- a/backend/src/main/java/org/example/backend/room/repository/MentoringRoomRepository.java
+++ b/backend/src/main/java/org/example/backend/room/repository/MentoringRoomRepository.java
@@ -1,0 +1,7 @@
+package org.example.backend.room.repository;
+
+import org.example.backend.room.domain.MentoringRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MentoringRoomRepository extends JpaRepository<MentoringRoom, Long> {
+}


### PR DESCRIPTION
feat: 멘토의 예약 승인 시 멘토링 방 생성 기능 구현

- PATCH /api/reservations/{reservationId}/approve API 추가
- ReservationService에 approveReservationResponse() 메서드 구현
  - 예약 ID로 예약 조회
  - 이미 ACCEPT 상태일 경우 예외 발생
  - 상태를 ACCEPT로 변경
  - MentoringRoom 엔티티 생성 및 DB 저장
- roomCode는 6자리 랜덤 영문+숫자 코드로 생성
- ApproveReservationResponseDTO 를 통해 roomId, roomCode, 멘토/유저 닉네임 응답
- MentoringReservation 엔티티에 approve() 도메인 메서드 추가
- 테스트용 예약 데이터로 Postman PATCH 요청 성공 확인