### PR TITLE
Pass38

### DIFF
--- a/backend/src/main/java/org/example/backend/auth/controller/AuthController.java
+++ b/backend/src/main/java/org/example/backend/auth/controller/AuthController.java
@@ -1,18 +1,20 @@
 package org.example.backend.auth.controller;
 
+import com.nimbusds.openid.connect.sdk.UserInfoResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.example.backend.auth.domain.CustomUserDetails;
 import org.example.backend.auth.dto.LoginRequestDto;
+import org.example.backend.auth.dto.LoginResponseDto;
 import org.example.backend.auth.dto.SignupRequestDto;
+import org.example.backend.auth.dto.UserInfoResponseDto;
 import org.example.backend.auth.service.AuthService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -29,10 +31,14 @@ public class AuthController {
 
     // 로그인
     @PostMapping("/login")
-    public ResponseEntity<String> login(@Valid @RequestBody LoginRequestDto requestDto, HttpServletResponse response) {
-        authService.login(requestDto, response);
-        return ResponseEntity.ok("로그인 성공! 토큰 발급 완료");
+    public ResponseEntity<LoginResponseDto> login(
+            @RequestBody LoginRequestDto requestDto,
+            HttpServletResponse response) {
+
+        LoginResponseDto loginResponse = authService.login(requestDto, response);
+        return ResponseEntity.ok(loginResponse);
     }
+
     // 로그아웃
     @PostMapping("/logout")
     public ResponseEntity<?> logout(HttpServletRequest request, HttpServletResponse response){
@@ -47,4 +53,14 @@ public class AuthController {
         authService.reissue(request,response);
         return ResponseEntity.ok("AccessToken 재발급 완료");
     }
+
+    // 유저 토큰 확인
+    @GetMapping("/me")
+    public ResponseEntity<?> getMyInfo(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUserId();
+        String username = userDetails.getUsername(); // Spring Security 기본 제공
+        return ResponseEntity.ok(new UserInfoResponseDto(userId, username));
+    }
+
+
 }

--- a/backend/src/main/java/org/example/backend/auth/dto/LoginResponseDto.java
+++ b/backend/src/main/java/org/example/backend/auth/dto/LoginResponseDto.java
@@ -1,0 +1,12 @@
+package org.example.backend.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponseDto {
+    private Long userId;
+    private String nickname;
+    private String role;
+}

--- a/backend/src/main/java/org/example/backend/auth/dto/UserInfoResponseDto.java
+++ b/backend/src/main/java/org/example/backend/auth/dto/UserInfoResponseDto.java
@@ -1,0 +1,3 @@
+package org.example.backend.auth.dto;
+
+public record UserInfoResponseDto(Long userId, String username) {}

--- a/backend/src/main/java/org/example/backend/auth/service/AuthService.java
+++ b/backend/src/main/java/org/example/backend/auth/service/AuthService.java
@@ -3,13 +3,14 @@ package org.example.backend.auth.service;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.example.backend.auth.dto.LoginRequestDto;
+import org.example.backend.auth.dto.LoginResponseDto;
 import org.example.backend.auth.dto.SignupRequestDto;
 
 public interface AuthService {
 
     void signup(SignupRequestDto requestDto);
 
-    void login(LoginRequestDto requestDto, HttpServletResponse response);
+    LoginResponseDto login(LoginRequestDto requestDto, HttpServletResponse response);
 
     void logout(HttpServletRequest request, HttpServletResponse response);
 

--- a/backend/src/main/java/org/example/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/org/example/backend/config/SecurityConfig.java
@@ -19,6 +19,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
+            .cors(cors -> {})
             .csrf(csrf -> csrf.disable())
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth

--- a/backend/src/main/java/org/example/backend/config/WebConfig.java
+++ b/backend/src/main/java/org/example/backend/config/WebConfig.java
@@ -16,11 +16,12 @@ public class WebConfig {
     public CorsFilter corsFilter() {
         CorsConfiguration config = new CorsConfiguration();
 
-        config.setAllowCredentials(true); // 쿠키 허용
-        config.setAllowedOriginPatterns(Arrays.asList("http://localhost:5173")); // 프론트 주소
+        config.setAllowCredentials(true);
+        config.setAllowedOrigins(Arrays.asList("http://localhost:5173")); // 더 명확하게 지정
         config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(Arrays.asList("*"));
-        config.setExposedHeaders(Arrays.asList("Authorization", "Set-Cookie")); // JWT + 쿠키 확인용
+        config.setExposedHeaders(Arrays.asList("Authorization", "Set-Cookie")); // 쿠키 응답 노출
+
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config); // 모든 경로에 대해 적용

--- a/backend/src/main/java/org/example/backend/mentor/domain/MentorUser.java
+++ b/backend/src/main/java/org/example/backend/mentor/domain/MentorUser.java
@@ -19,7 +19,7 @@ public class MentorUser extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long mentorId;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)

--- a/backend/src/main/java/org/example/backend/mentor/repository/MentorRepository.java
+++ b/backend/src/main/java/org/example/backend/mentor/repository/MentorRepository.java
@@ -2,10 +2,17 @@
 package org.example.backend.mentor.repository;
 
 import org.example.backend.mentor.domain.MentorUser;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface MentorRepository extends JpaRepository<MentorUser, Long> {
-    //멘토 엔티티를 조회하기 위한 jpaRepository를 상속받는 인터페이스.
+
+    @EntityGraph(attributePaths = "user") // 강제로 user 같이 가져오도록 지정
+    @Query("SELECT m FROM MentorUser m") // 명시적 쿼리 사용
+    List<MentorUser> findAllWithUser();           // 이름은 그대로 유지해도 됨
 }

--- a/backend/src/main/java/org/example/backend/mentor/service/MentorService.java
+++ b/backend/src/main/java/org/example/backend/mentor/service/MentorService.java
@@ -23,15 +23,20 @@ public class MentorService {
 
     // ① getAllMentors 같은 퍼블릭 서비스 메서드
     public List<MentorDto> getAllMentors() {
-        return mentorRepository.findAll().stream()
+        return mentorRepository.findAllWithUser().stream()
                 .map(this::convertToDto)   // 여기서 호출
                 .collect(Collectors.toList());
     }
 
     // ② convertToDto 메서드: 서비스 클래스 내부에 private으로 추가
     private MentorDto convertToDto(MentorUser m) {
-        long reviewCount = reviewRepository.countByMentorId(m.getMentorId());
-        Double avg = reviewRepository.findAverageRatingByMentorId(m.getMentorId());
+
+        if (m.getUser() == null) {
+            throw new IllegalStateException("MentorUser에 연결된 User가 없습니다. id=" + m.getId());
+        }
+
+        long reviewCount = reviewRepository.countByMentorId(m.getId());
+        Double avg = reviewRepository.findAverageRatingByMentorId(m.getId());
         double rating = (avg != null)
                 ? Math.round(avg * 10) / 10.0
                 : 0.0;

--- a/backend/src/main/java/org/example/backend/reservation/service/ReservationServiceImpl.java
+++ b/backend/src/main/java/org/example/backend/reservation/service/ReservationServiceImpl.java
@@ -98,7 +98,7 @@ public class ReservationServiceImpl implements ReservationService {
     MentoringReservation reservation = reservationRepository.findById(reservationId)
         .orElseThrow(() -> new IllegalArgumentException("해당 예약이 존재하지 않습니다."));
 
-    if (!reservation.getMentor().getMentorId().equals(mentorUserId)) {
+    if (!reservation.getMentor().getId().equals(mentorUserId)) {
       throw new AccessDeniedException("예약에 대한 권한이 없습니다.");
     }
 

--- a/backend/src/main/java/org/example/backend/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/org/example/backend/review/repository/ReviewRepository.java
@@ -12,9 +12,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     List<Review> findByMentor(MentorUser mentor);
 
-    @Query("SELECT COUNT(r) FROM Review r WHERE r.mentor.mentorId = :mentorId")
     long countByMentorId(@Param("mentorId") Long mentorId);
 
-    @Query("SELECT AVG(r.rating) FROM Review r WHERE r.mentor.mentorId = :mentorId")
+    @Query("SELECT AVG(r.rating) FROM Review r WHERE r.mentor.id = :mentorId")
     Double findAverageRatingByMentorId(@Param("mentorId") Long mentorId);
 }

--- a/backend/src/main/java/org/example/backend/review/service/ReviewService.java
+++ b/backend/src/main/java/org/example/backend/review/service/ReviewService.java
@@ -60,7 +60,7 @@ public class ReviewService {
 
         return ReviewDto.CreateResponse.builder()
                 .reviewId(savedReview.getReviewId())
-                .mentorId(savedReview.getMentor().getMentorId())
+                .mentorId(savedReview.getMentor().getId())
                 .rating(savedReview.getRating())
                 .content(savedReview.getContent())
                 .createdAt(savedReview.getCreatedAt())


### PR DESCRIPTION
- MentorUser 엔티티의 primary key 필드명을 기존 'mentorId' → 'id' 로 변경
  └ 표준 엔티티 설계 가이드에 맞추기 위한 리팩토링
- 해당 변경에 따라 Review 생성 시 `.getMentor().getMentorId()` → `.getMentor().getId()`로 변경
- MentorService 내 `convertToDto()` 메서드의 리뷰 조회 로직에서도 동일하게 `.getId()`로 수정
- 변경된 필드명을 사용하는 전체 로직 및 레이어별(Repository, DTO 등) 영향 코드 반영 완료

ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ

- LoginResponseDto에 필요한 사용자 정보 필드 확장
  └ 클라이언트에서 로그인 후 사용자 식별자, 권한 등을 활용 가능하도록 개선
- UserInfoResponseDto 생성 및 적용
  └ 로그인한 사용자 정보 조회 시 응답 DTO 분리
- AuthService, AuthController, AuthServiceImpl 등 인증 관련 클래스 로직 리팩토링
  └ 리팩토링 및 response 형식 일관성 확보
- WebConfig, SecurityConfig에서 CORS 및 인터셉터 관련 설정 추가 및 수정
  └ 프론트 도메인 연동과 OPTIONS preflight 요청 대응
