### PR TITLE
fix:멘토링 소개글 수정페이지 관련 수정작업

### DIFF
--- a/backend/src/main/java/org/example/backend/mentor/controller/MentorController.java
+++ b/backend/src/main/java/org/example/backend/mentor/controller/MentorController.java
@@ -72,8 +72,8 @@ public class MentorController {
     @GetMapping("/me/profile")
     public ResponseEntity<MentorProfileResponseDto> getMentorProfile(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Long mentorId = userDetails.getUserId();
-        MentorProfileResponseDto profile = mentorService.getMentorProfile(mentorId);
+        Long userId = userDetails.getUserId(); // 변수명을 mentorId -> userId로 변경
+        MentorProfileResponseDto profile = mentorService.getMentorProfile(userId);
         return ResponseEntity.ok(profile);
     }
 

--- a/backend/src/main/java/org/example/backend/mentor/service/MentorService.java
+++ b/backend/src/main/java/org/example/backend/mentor/service/MentorService.java
@@ -52,9 +52,14 @@ public class MentorService {
     /**
      * [수정] 현재 로그인한 멘토의 프로필 설정 정보를 조회합니다.
      */
-    public MentorProfileResponseDto getMentorProfile(Long mentorId) {
-        MentorUser mentorUser = mentorRepository.findById(mentorId)
-                .orElseThrow(() -> new IllegalArgumentException("멘토를 찾을 수 없습니다."));
+    public MentorProfileResponseDto getMentorProfile(Long userId) { // 파라미터를 mentorId -> userId로 변경
+        // userId를 사용하여 User 엔티티 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저를 찾을 수 없습니다. userId=" + userId));
+
+        // User 엔티티를 사용하여 MentorUser 조회
+        MentorUser mentorUser = mentorRepository.findByUser(user)
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저에 연결된 멘토 정보를 찾을 수 없습니다. userId=" + userId));
 
         List<FieldDto> fields = mentorUser.getFields().stream()
                 .map(f -> new FieldDto(f.getFieldName()))


### PR DESCRIPTION
1. `MentorService.java` 수정:
  * getMentorProfile 메서드가 mentorId 대신 userId를 매개변수로 받도록 변경했습니다.
  * 메서드 내부 로직을, 전달받은 userId를 통해 User 정보를 먼저 찾고, 그 User 정보와 연결된 MentorUser 정보를 조회하도록 수정
2. `MentorController.java` 수정:
  * getMentorProfile API 메서드에서 CustomUserDetails로부터 얻은 ID를 userId 변수로 명확히 하여 MentorService에 전달하도록 수정